### PR TITLE
Fix potential conflict with `compose` alias in `racket/base`

### DIFF
--- a/implementation.rkt
+++ b/implementation.rkt
@@ -17,7 +17,6 @@
                        (rename-in racket/base
                                   [* mul]
                                   [+ plus]
-                                  [compose ∘]
                                   [... …])
                        racket/syntax
                        racket/match
@@ -38,6 +37,7 @@
   (provide xlist ^ ∞ once (for-syntax normalize-xlist-type))
 
   (begin-for-syntax
+    (define ∘ compose)
     (define-syntax ~^
       (pattern-expander
        (λ (stx)


### PR DESCRIPTION
This PR replaces `(require (rename-in racket/base [compose ∘]))` with `(define ∘ compose)` to avoid potential conflicts caused by the planned addition of `∘` as an alias for `compose` in `racket/base`: https://github.com/racket/racket/pull/5115 .
